### PR TITLE
fix bug where date property change is ignored

### DIFF
--- a/src/react-date-fns-hooks.tsx
+++ b/src/react-date-fns-hooks.tsx
@@ -63,11 +63,13 @@ export function useDateFunction<T>(
   opts: { baseDate?: DateLike; locale?: Locale } = {}
 ): T {
   useDebugValue(date, (date) => new Date(date).toISOString());
+  const currDate = useRef(date);
+  currDate.current = date;
   const context = useContext(DateFnsContext);
 
   function calculateValue() {
     return calculation(
-      new Date(date),
+      new Date(currDate.current),
       new Date(opts.baseDate || context.baseDate || new Date()),
       opts.locale || context.locale
     );


### PR DESCRIPTION
I'v noticed that changing date property does affect the component. it seems that the original date is cloned and persisted in some internal function's closure. 

This can also be seen in storybook - change the `date` property of `FormatDistance` .
expected: counter updated to display distance from new date. actual: keeps showing distance from old date.

This fix worked for me, can be verified by using same storybook flow.

I did not have time to invest in a failing test :(